### PR TITLE
Create config

### DIFF
--- a/config
+++ b/config
@@ -1,0 +1,6 @@
+[framework/core]
+consolelogging=true
+loglevel=3
+sessionlogging=true
+sessiontlvlogging=true
+timestampoutput=true


### PR DESCRIPTION
Simple way to enable verbose logging in `msfconsole`.

Usage: Put the `config` file in Metasploit Framework root folder i.e, `.msf4`